### PR TITLE
Hack around web assembly requiring an async loading. We will wait for…

### DIFF
--- a/lib/cnUtil.js
+++ b/lib/cnUtil.js
@@ -4,7 +4,7 @@ const {mn_random, mn_encode} = require('./mnemonic');
 
 // Module compile in safex crypto with
 // emcc hash.c keccak.c crypto-ops.c crypto-ops-data.c  -s EXPORTED_FUNCTIONS='["_ge_add","_ge_double_scalarmult_base_vartime","_ge_p3_to_cached","_ge_p1p1_to_p2","_ge_p1p1_to_p3","_ge_mul8","_ge_fromfe_frombytes_vartime","_ge_scalarmult_base","_ge_frombytes_vartime","_sc_check","_sc_isnonzero","_ge_double_scalarmult_base_vartime","_ge_tobytes","_ge_p3_tobytes","_sc_sub","_sc_reduce32","_sc_mulsub","_ge_scalarmult","_sc_add","_sc_0","_ge_double_scalarmult_precomp_vartime","_ge_dsm_precomp", "_keccak","_sc_reduce", "_cn_fast_hash", "_malloc","_free"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall","cwrap"]' -I../../contrib/epee/include  -I/home/igor/test/inc -I../  -o safex_module.js -s MODULARIZE=1  -O2
-const Module = require('./safex_module.js');
+const Module = require('./safex_module_sync.js');
 
 const cnBase58 = require('./cnBase58');
 const keccak256 = require('keccak256')
@@ -275,7 +275,7 @@ function CnUtil() {
         Module._free(res_m);
         return bintohex(res);
     };
-  
+
     this.verify_checksum = function (address) {
         var dec = cnBase58.decode(address);
         var checksum = dec.slice(dec.length - 8);
@@ -520,9 +520,9 @@ function CnUtil() {
             }
         }
         // No non-zero bytes
-        return false; 
+        return false;
     };
-    
+
     //WIP
     this.check_signature = function(signature) {
 

--- a/lib/safex_module_sync.js
+++ b/lib/safex_module_sync.js
@@ -1,0 +1,18 @@
+const sleep = require('system-sleep');
+
+const initModule = require('./safex_module');
+
+var Module;
+initModule().then((loadedModule) => {
+    Module = loadedModule;
+}, err => {
+    // Nothing we can do
+    console.error("Failed to load safex module", err);
+    Module = {};
+});
+
+while (!Module) {
+    sleep(10);
+}
+
+module.exports = Module;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,14 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bn.js": {
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
@@ -81,6 +89,30 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "deasync": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.21.tgz",
+      "integrity": "sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^1.7.1"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+          "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="
+        }
+      }
+    },
+    "deasync-promise": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deasync-promise/-/deasync-promise-1.0.1.tgz",
+      "integrity": "sha1-KyfeR4Fnr07zS6mYecUuwM7dYcI=",
+      "requires": {
+        "deasync": "^0.1.7"
+      }
+    },
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -110,6 +142,11 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -282,6 +319,14 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "system-sleep": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/system-sleep/-/system-sleep-1.3.7.tgz",
+      "integrity": "sha512-0Bd7sdWpO+UNLwPr7I4fhmaYf5RARbx4LQPgEPHVqU+uYc1C7FMfxyEWZlJXHpcGmtSR7KeR9npNpool+s8TvQ==",
+      "requires": {
+        "deasync-promise": "1.0.1"
       }
     },
     "type-detect": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "url": "git@github.com:safex/safex_addressjs.git"
   },
   "dependencies": {
-    "keccak256": "^1.0.1"
+    "keccak256": "^1.0.1",
+    "system-sleep": "^1.3.7"
   }
 }


### PR DESCRIPTION
… module to load during require, then use it in resolved state.

At some point, we might want to look into making WebAssembly generate sync loading code for nodejs, or refactoring the code to be async. Either would be a better fix for this.