### PR TITLE
Allow usage of library only after calling initialize()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,19 @@
 const cnUtil = require('./lib/cnUtil');
-const { cn_fast_hash_safex, check_signature, sign_message, sc_reduce32, rand_32, create_address, pubkeys_to_string, address_checksum, sec_key_to_pub, structure_keys, decode_address, verify_checksum } = cnUtil;
+const {
+    cn_fast_hash_safex,
+    check_signature,
+    sign_message,
+    sc_reduce32,
+    rand_32,
+    create_address,
+    pubkeys_to_string,
+    address_checksum,
+    sec_key_to_pub,
+    structure_keys,
+    decode_address,
+    verify_checksum,
+    initialize
+} = cnUtil;
 
 module.exports = {
     sc_reduce32,
@@ -13,10 +27,11 @@ module.exports = {
     verify_checksum,
     sign_message,
     check_signature,
-    cn_fast_hash_safex
+    cn_fast_hash_safex,
+    initialize
 };
 
 // Bind the exports to cnUtil
 for (const key in module.exports) {
-  module.exports[key] = module.exports[key].bind(cnUtil);
+    module.exports[key] = module.exports[key].bind(cnUtil);
 }

--- a/lib/cnUtil.js
+++ b/lib/cnUtil.js
@@ -4,7 +4,7 @@ const {mn_random, mn_encode} = require('./mnemonic');
 
 // Module compile in safex crypto with
 // emcc hash.c keccak.c crypto-ops.c crypto-ops-data.c  -s EXPORTED_FUNCTIONS='["_ge_add","_ge_double_scalarmult_base_vartime","_ge_p3_to_cached","_ge_p1p1_to_p2","_ge_p1p1_to_p3","_ge_mul8","_ge_fromfe_frombytes_vartime","_ge_scalarmult_base","_ge_frombytes_vartime","_sc_check","_sc_isnonzero","_ge_double_scalarmult_base_vartime","_ge_tobytes","_ge_p3_tobytes","_sc_sub","_sc_reduce32","_sc_mulsub","_ge_scalarmult","_sc_add","_sc_0","_ge_double_scalarmult_precomp_vartime","_ge_dsm_precomp", "_keccak","_sc_reduce", "_cn_fast_hash", "_malloc","_free"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall","cwrap"]' -I../../contrib/epee/include  -I/home/igor/test/inc -I../  -o safex_module.js -s MODULARIZE=1  -O2
-const Module = require('./safex_module.js');
+const initModule = require('./safex_module.js');
 
 const cnBase58 = require('./cnBase58');
 const keccak256 = require('keccak256')
@@ -12,6 +12,9 @@ const keccak256 = require('keccak256')
 const SAFEX_ADDRESS_PREFIX = 0x10003798;
 
 function CnUtil() {
+    var Module;
+    var initializePromise = null;
+
     var HASH_STATE_BYTES = 200;
     var HASH_SIZE = 32;
     var ADDRESS_CHECKSUM_SIZE = 4;
@@ -275,7 +278,7 @@ function CnUtil() {
         Module._free(res_m);
         return bintohex(res);
     };
-  
+
     this.verify_checksum = function (address) {
         var dec = cnBase58.decode(address);
         var checksum = dec.slice(dec.length - 8);
@@ -520,9 +523,9 @@ function CnUtil() {
             }
         }
         // No non-zero bytes
-        return false; 
+        return false;
     };
-    
+
     //WIP
     this.check_signature = function(signature) {
 
@@ -615,6 +618,60 @@ function CnUtil() {
         var expected_spend_pub = this.sec_key_to_pub(spend_sec);
         return (expected_spend_pub === spend_pub) && (expected_view_pub === view_pub);
     };
+
+    // *****************************************************************************************************************
+
+    const INITIALIZE_METHODS = [
+        'sc_reduce',
+        'sc_reduce32',
+        'ge_scalarmult_base',
+        'ge_p3_tobytes',
+        'keccak',
+        'hash_to_ec',
+        'generate_key_derivation',
+        'derive_public_key',
+        'keccak_safex',
+        'sign_message',
+        'check_signature',
+        'derive_secret_key',
+    ];
+
+    // Make sure initialize-needing methods can't be called before initialize
+    function failBecauseNotInitialized() {
+        throw new Error("Safex module hasn't been initialized. You must call initialize() first and wait for its promise before using this library.");
+    }
+
+    var instance = this;
+    var saveMethods = [];
+    INITIALIZE_METHODS.forEach(function (methodName) {
+        saveMethods.push(instance[methodName]);
+        instance[methodName] = failBecauseNotInitialized;
+    });
+
+    this.initialize = function () {
+        if (!initializePromise) {
+            initializePromise = initModule().then(
+                initializedModule => {
+                    // Make module available to be used
+                    Module = initializedModule;
+
+                    // Restore actual methods
+                    INITIALIZE_METHODS.forEach(function (methodName, index) {
+                        instance[methodName] = saveMethods[index];
+                    });
+
+                    return initializedModule;
+                },
+                err => {
+                    console.error(`Failed to initialize safex_module`, err);
+                    throw err;
+                }
+            );
+        }
+
+        return initializePromise;
+    };
+
 }
 
 module.exports = new CnUtil();


### PR DESCRIPTION
Example usage:
```
const sa = require('../index');

function main() {
    sa.initialize().then(() => {
        let msggg = 'hehehe';
        let msg_hashhh = sa.cn_fast_hash_safex(msggg, msggg.length);
        console.log(msg_hashhh);
    });
}
```